### PR TITLE
Fix release number 1.0.0-RC3-SNAPSHOT -> 1.0.1-SNAPHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.spdx</groupId>
   <artifactId>spdx-java-model-3_0</artifactId>
-  <version>1.0.0-RC3-SNAPSHOT</version>
+  <version>1.0.1-SNAPSHOT</version>
   <name>spdx-java-model-3</name>
   <description>Generated java model source code</description>
 <url>https://github.com/spdx/spdx-java-model-3_0</url>


### PR DESCRIPTION
Since we already have the [1.0.0](https://github.com/spdx/spdx-java-model-3_0/releases/tag/v1.0.0), the next release number should increment.